### PR TITLE
Remove optional full path to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "scripts": {
-    "zapier-build": "rm -rf lib && node_modules/babel-cli/bin/babel.js src --out-dir lib",
-    "zapier-dev": "rm -rf lib && node_modules/babel-cli/bin/babel.js src --out-dir lib --watch",
+    "zapier-build": "rm -rf lib && babel src --out-dir lib",
+    "zapier-dev": "rm -rf lib && babel src --out-dir lib --watch",
     "zapier-push": "npm run zapier-build && zapier push",
-    "test": "npm run zapier-build && node node_modules/mocha/bin/mocha --recursive lib"
+    "test": "npm run zapier-build && mocha --recursive lib"
   },
   "engines": {
     "node": "6.10.3",


### PR DESCRIPTION
We can reference the `mocha` binary directly since `npm` will resolve the full path it for us.