### PR TITLE
Allow use of polyfill in actual code and upgrade dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 4
+        "node": 6
       }
     }]
   ],

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-process.env.BABEL_DISABLE_CACHE = 1;
-
 global._babelPolyfill || require('babel-polyfill');
 
 module.exports = require('./lib');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 process.env.BABEL_DISABLE_CACHE = 1;
 
-global._babelPolyfill || require("babel-polyfill");
+global._babelPolyfill || require('babel-polyfill');
 
 module.exports = require('./lib');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,5 @@
+process.env.BABEL_DISABLE_CACHE = 1;
+
+global._babelPolyfill || require("babel-polyfill");
+
 module.exports = require('./lib');

--- a/package.json
+++ b/package.json
@@ -13,25 +13,24 @@
     "zapier-push": "npm run zapier-build && zapier push",
     "prepare": "npm run zapier-build",
     "pretest": "npm run zapier-build",
-    "test": "mocha --recursive lib"
+    "test": "mocha --recursive lib --require babel-polyfill"
   },
   "engines": {
     "node": "6.10.3",
     "npm": ">=3.10.10"
   },
   "dependencies": {
-    "lodash": "4.17.4",
+    "babel-polyfill": "6.26.0",
     "zapier-platform-core": "5.1.0"
   },
   "devDependencies": {
-    "babel-cli": "6.24.1",
-    "babel-core": "6.24.1",
-    "babel-eslint": "7.2.2",
+    "babel-cli": "6.26.0",
+    "babel-core": "6.26.0",
+    "babel-eslint": "8.2.3",
     "babel-plugin-add-module-exports": "0.2.1",
-    "babel-plugin-transform-regenerator": "6.24.1",
-    "babel-polyfill": "6.23.0",
-    "babel-preset-env": "1.4.0",
-    "mocha": "2.5.3",
-    "should": "11.2.1"
+    "babel-plugin-transform-regenerator": "6.26.0",
+    "babel-preset-env": "1.6.1",
+    "mocha": "5.1.0",
+    "should": "13.2.1"
   }
 }

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,27 +1,27 @@
-const test = (z /*, bundle*/) => {
+const test = async (z /*, bundle*/) => {
   // Normally you want to make a request to an endpoint that is either specifically designed to test auth, or one that
   // every user will have access to, such as an account or profile endpoint like /me.
   // In this example, we'll hit httpbin, which validates the Authorization Header against the arguments passed in the URL path
-  const promise = z.request({
+  const response = await z.request({
     url: 'https://auth-json-server.zapier.ninja/me',
   });
 
   // This method can return any truthy value to indicate the credentials are valid.
   // Raise an error to show
-  return promise.then((response) => {
-    if (response.status === 401) {
-      throw new Error('The username and/or password you supplied is incorrect');
-    }
-    return response;
-  });
+  if (response.status === 401) {
+    throw new Error('The username and/or password you supplied is incorrect');
+  }
+  return response;
 };
 
-module.exports = {
+const Authentication = {
   type: 'basic',
 
   // The test method allows Zapier to verify that the credentials a user provides are valid. We'll execute this
   // method whenver a user connects their account for the first time.
-  test: test,
+  test,
   // assuming "username" is a key returned from the test
   connectionLabel: '{{username}}'
 };
+
+export default Authentication;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import authentication from './authentication';
+import Authentication from './authentication';
 import Recipe from './resources/recipe';
 import { version } from '../package.json';
 import { version as platformVersion } from 'zapier-platform-core';
@@ -7,7 +7,7 @@ const App = {
   version,
   platformVersion,
 
-  authentication: authentication,
+  authentication: Authentication,
 
   beforeRequest: [
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,11 @@
-import { loadBabel } from './tools';
-loadBabel();
-
-const exampleFunc = async (z, bundle) => {
-  const response = await z.request('http://example.com/api.json');
-  return z.json.parse(response.content);
-};
-
-const Recipe = require('./resources/recipe');
-
-const authentication = require('./authentication');
+import authentication from './authentication';
+import Recipe from './resources/recipe';
+import { version } from '../package.json';
+import { version as platformVersion } from 'zapier-platform-core';
 
 const App = {
-  version: require('../package.json').version,
-  platformVersion: require('zapier-platform-core').version,
+  version,
+  platformVersion,
 
   authentication: authentication,
 

--- a/src/resources/recipe.js
+++ b/src/resources/recipe.js
@@ -4,7 +4,7 @@ const getRecipe = async (z, bundle) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`,
   });
-  return JSON.parse(response.content);
+  return z.JSON.parse(response.content);
 };
 
 const listRecipes = async (z, bundle) => {
@@ -14,7 +14,7 @@ const listRecipes = async (z, bundle) => {
       style: bundle.inputData.style
     }
   });
-  return JSON.parse(response.content);
+  return z.JSON.parse(response.content);
 };
 
 const createRecipe = async (z, bundle) => {
@@ -30,7 +30,7 @@ const createRecipe = async (z, bundle) => {
       'content-type': 'application/json'
     }
   });
-  return JSON.parse(response.content);
+  return z.JSON.parse(response.content);
 };
 
 const searchRecipe = async (z, bundle) => {
@@ -40,7 +40,7 @@ const searchRecipe = async (z, bundle) => {
       nameSearch: bundle.inputData.name
     }
   });
-  const matchingRecipes = JSON.parse(response.content);
+  const matchingRecipes = z.JSON.parse(response.content);
 
   // Only return the first matching recipe
   if (matchingRecipes && matchingRecipes.length) {
@@ -61,7 +61,7 @@ const sample = {
 
 // This file exports a Recipe resource. The definition below contains all of the keys available,
 // and implements the list and create methods.
-const Config = {
+const Recipe = {
   key: 'recipe',
   noun: 'Recipe',
   // The get method is used by Zapier to fetch a complete representation of a record. This is helpful when the HTTP
@@ -151,4 +151,4 @@ const Config = {
   ]
 };
 
-export default Config;
+export default Recipe;

--- a/src/resources/recipe.js
+++ b/src/resources/recipe.js
@@ -1,24 +1,24 @@
 const _sharedBaseUrl = 'https://auth-json-server.zapier.ninja';
 
-const getRecipe = (z, bundle) => {
-  return z.request({
-      url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`,
-    })
-    .then((response) => JSON.parse(response.content));
+const getRecipe = async (z, bundle) => {
+  const response = await z.request({
+    url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`,
+  });
+  return JSON.parse(response.content);
 };
 
-const listRecipes = (z, bundle) => {
-  return z.request({
-      url: _sharedBaseUrl + '/recipes',
-      params: {
-        style: bundle.inputData.style
-      }
-    })
-    .then((response) => JSON.parse(response.content));
+const listRecipes = async (z, bundle) => {
+  const response = await z.request({
+    url: _sharedBaseUrl + '/recipes',
+    params: {
+      style: bundle.inputData.style
+    }
+  });
+  return JSON.parse(response.content);
 };
 
-const createRecipe = (z, bundle) => {
-  const requestOptions = {
+const createRecipe = async (z, bundle) => {
+  const response = await z.request({
     url: _sharedBaseUrl + '/recipes',
     method: 'POST',
     body: JSON.stringify({
@@ -29,29 +29,25 @@ const createRecipe = (z, bundle) => {
     headers: {
       'content-type': 'application/json'
     }
-  };
-
-  return z.request(requestOptions)
-    .then((response) => JSON.parse(response.content));
+  });
+  return JSON.parse(response.content);
 };
 
-const searchRecipe = (z, bundle) => {
-  return z.request({
-      url: _sharedBaseUrl + '/recipes',
-      params: {
-        nameSearch: bundle.inputData.name
-      }
-    })
-    .then((response) => {
-      const matchingRecipes = JSON.parse(response.content);
+const searchRecipe = async (z, bundle) => {
+  const response = await z.request({
+    url: _sharedBaseUrl + '/recipes',
+    params: {
+      nameSearch: bundle.inputData.name
+    }
+  });
+  const matchingRecipes = JSON.parse(response.content);
 
-      // Only return the first matching recipe
-      if (matchingRecipes && matchingRecipes.length) {
-        return matchingRecipes[0];
-      }
+  // Only return the first matching recipe
+  if (matchingRecipes && matchingRecipes.length) {
+    return matchingRecipes[0];
+  }
 
-      return [];
-    });
+  return [];
 };
 
 const sample = {
@@ -65,7 +61,7 @@ const sample = {
 
 // This file exports a Recipe resource. The definition below contains all of the keys available,
 // and implements the list and create methods.
-module.exports = {
+const Config = {
   key: 'recipe',
   noun: 'Recipe',
   // The get method is used by Zapier to fetch a complete representation of a record. This is helpful when the HTTP
@@ -81,7 +77,7 @@ module.exports = {
         {key: 'id', required: true},
       ],
       perform: getRecipe,
-      sample: sample
+      sample
     },
   },
   // The list method on this resource becomes a Trigger on the app. Zapier will use polling to watch for new records
@@ -95,7 +91,7 @@ module.exports = {
         {key: 'style', type: 'string', helpText: 'Explain what style of cuisine this is.'},
       ],
       perform: listRecipes,
-      sample: sample
+      sample
     },
   },
   // If your app supports webhooks, you can define a hook method instead of a list method.
@@ -118,7 +114,7 @@ module.exports = {
         {key: 'style', required: false, type: 'string', helpText: 'Explain what style of cuisine this is.'},
       ],
       perform: createRecipe,
-      sample: sample
+      sample
     },
   },
   // The search method on this resource becomes a Search on this app
@@ -132,14 +128,14 @@ module.exports = {
         {key: 'name', required: true, type: 'string'},
       ],
       perform: searchRecipe,
-      sample: sample
+      sample
     },
   },
 
   // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
   // from the API, Zapier will fallback to this hard-coded sample. It should reflect the data structure of
   // returned records, and have obviously dummy values that we can show to any user.
-  sample: sample,
+  sample,
 
   // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
   // field definitions. The result will be used to augment the sample.
@@ -154,3 +150,5 @@ module.exports = {
     {key: 'style', label: 'Style'},
   ]
 };
+
+export default Config;

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -2,23 +2,12 @@ import should from 'should';
 
 import zapier from 'zapier-platform-core';
 
-const App = require('../index');
+import App from '../index';
 const appTester = zapier.createAppTester(App);
-
-const mochaAsync = (fn) => {
-  return async (done) => {
-    try {
-      await fn();
-      done();
-    } catch (err) {
-      done(err);
-    }
-  };
-};
 
 describe('My Test', () => {
 
-  it('should test the auth succeeds', mochaAsync(async () => {
+  it('should test the auth succeeds', async () => {
     const bundle = {
       authData: {
         username: 'user',
@@ -29,9 +18,9 @@ describe('My Test', () => {
     const response = await appTester(App.authentication.test, bundle);
     should(response.status).eql(200);
     response.request.headers.Authorization.should.eql('Basic dXNlcjpzZWNyZXQ=');
-  }));
+  });
 
-  it('should test the auth fails', mochaAsync(async () => {
+  it('should test the auth fails', async () => {
     const bundle = {
       authData: {
         username: 'user',
@@ -44,6 +33,6 @@ describe('My Test', () => {
     } catch(e) {
       e.message.should.containEql('The username and/or password you supplied is incorrect');
     }
-  }));
+  });
 
 });

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,9 +1,0 @@
-export const loadBabel = () => {
-  process.env.BABEL_DISABLE_CACHE = 1;
-  require('babel-core/register');
-  try {
-    require('babel-polyfill');
-  } catch(err) {
-    process.babelAlreadyLoaded = true;
-  }
-};


### PR DESCRIPTION
I based an app off this example and ran into several issues that this PRs solves.

- Upgrade all dependencies to latest
- Drop `tools.loadBabel` and rely on `global._babelPolyfill` in `index.js` instead
- Bump babel env target from Node 4 to 6
- Pass `--require babel-polyfill` to mocha so that app (not just test) code can use polyfills
- Move `babel-polyfill` from `devDependencies` to `dependencies` since it's needed at run-time
- Refactor all code to use ES6 imports, awaits and all everywhere
- Drop `mochaAsync` wrapper from tests as latest mocha has out of the box support. Only for specific cases would one need this helper: https://staxmanade.com/2015/11/testing-asyncronous-code-with-mochajs-and-es7-async-await/

Note that I dropped use of `babel-register`. This can be done (both in Mocha with `--require=babel-register` as well as by adding to `index.js`) but then all babel dependencies need to be moved to `dependencies` as well.